### PR TITLE
Fix infinite recursion in abbrev_obj for circular references

### DIFF
--- a/src/prettyfmt/prettyfmt.py
+++ b/src/prettyfmt/prettyfmt.py
@@ -56,6 +56,7 @@ def _format_kvs(
     field_max_len: int,
     key_filter: KeyFilter | None = None,
     value_filter: Callable[[Any], bool] | None = None,
+    visited: set[Any] | None = None,
 ) -> str:
     filtered_items: list[tuple[Any, Any]] = []
     for k, v in items:
@@ -76,6 +77,7 @@ def _format_kvs(
                         field_max_len,
                         key_filter=key_filter,
                         value_filter=value_filter,
+                        visited=visited,
                     ),
                 )
             )
@@ -155,12 +157,12 @@ def abbrev_obj(
         value_dict = {f.name: getattr(value, f.name) for f in fields(value)}
         return (
             f"{name}("
-            + _format_kvs(value_dict.items(), field_max_len, key_filter, value_filter)
+            + _format_kvs(value_dict.items(), field_max_len, key_filter, value_filter, visited)
             + ")"
         )
 
     if isinstance(value, dict):
-        return "{" + _format_kvs(value.items(), field_max_len, key_filter, value_filter) + "}"  # pyright: ignore
+        return "{" + _format_kvs(value.items(), field_max_len, key_filter, value_filter, visited) + "}"  # pyright: ignore
 
     if isinstance(value, Enum):
         return value.name

--- a/src/prettyfmt/prettyfmt.py
+++ b/src/prettyfmt/prettyfmt.py
@@ -162,7 +162,9 @@ def abbrev_obj(
         )
 
     if isinstance(value, dict):
-        return "{" + _format_kvs(value.items(), field_max_len, key_filter, value_filter, visited) + "}"  # pyright: ignore
+        return (
+            "{" + _format_kvs(value.items(), field_max_len, key_filter, value_filter, visited) + "}"  # pyright: ignore
+        )
 
     if isinstance(value, Enum):
         return value.name

--- a/tests/test_circular_references.py
+++ b/tests/test_circular_references.py
@@ -1,0 +1,99 @@
+from prettyfmt import abbrev_obj
+
+
+def test_circular_dict():
+    d = {"key": "value"}
+    d["self"] = d  # pyright: ignore
+    result = abbrev_obj(d)
+    assert "<circular reference>" in result
+    assert "key=value" in result
+
+
+def test_circular_list():
+    lst = ["item1", "item2"]
+    lst.append(lst)  # pyright: ignore
+    result = abbrev_obj(lst)
+    assert "<circular reference>" in result
+    assert "item1" in result
+    assert "item2" in result
+
+
+def test_mutual_reference():
+    d1 = {"name": "dict1"}
+    d2 = {"name": "dict2"}
+    d1["other"] = d2  # pyright: ignore
+    d2["other"] = d1  # pyright: ignore
+    result = abbrev_obj(d1)
+    assert "<circular reference>" in result
+    assert "name=dict1" in result
+    assert "name=dict2" in result
+
+
+def test_nested_circular():
+    d1 = {"level": 1}
+    d2 = {"level": 2, "parent": d1}
+    d3 = {"level": 3, "parent": d2}
+    d1["child"] = d2  # pyright: ignore
+    d2["child"] = d3  # pyright: ignore
+    d3["root"] = d1  # pyright: ignore
+    result = abbrev_obj(d1)
+    assert "<circular reference>" in result
+    assert "level=1" in result
+
+
+def test_list_with_circular_dict():
+    d1 = {"id": 1}
+    d2 = {"id": 2}
+    d1["ref"] = d2  # pyright: ignore
+    d2["ref"] = d1  # pyright: ignore
+    lst = [d1, d2]
+    result = abbrev_obj(lst)
+    assert "<circular reference>" in result
+    assert "id=1" in result
+    assert "id=2" in result
+
+
+def test_deep_nesting_without_circular():
+    d1 = {"level": 1}
+    d2 = {"level": 2, "parent": d1}
+    d3 = {"level": 3, "parent": d2}
+    d4 = {"level": 4, "parent": d3}
+    result = abbrev_obj(d4)
+    assert "<circular reference>" not in result
+    assert "level=4" in result
+    assert "level=3" in result
+    assert "level=2" in result
+    assert "level=1" in result
+
+
+def test_self_referencing_in_nested_structure():
+    inner = {"name": "inner"}
+    outer = {"name": "outer", "nested": inner}
+    inner["parent"] = outer  # pyright: ignore
+    result = abbrev_obj(outer)
+    assert "<circular reference>" in result
+    assert "name=outer" in result
+    assert "name=inner" in result
+
+
+def test_list_containing_self():
+    lst = [1, 2, 3]
+    container = {"items": lst, "self_list": None}
+    container["self_list"] = container  # pyright: ignore
+    result = abbrev_obj(container)
+    assert "<circular reference>" in result
+    assert "[1, 2, 3]" in result
+
+
+def test_multiple_circular_references():
+    d1 = {"id": "d1"}
+    d2 = {"id": "d2"}
+    d3 = {"id": "d3"}
+    
+    d1["refs"] = [d2, d3]  # pyright: ignore
+    d2["refs"] = [d1, d3]  # pyright: ignore
+    d3["refs"] = [d1, d2]  # pyright: ignore
+    
+    result = abbrev_obj(d1)
+    assert "<circular reference>" in result
+    assert "id=d1" in result

--- a/tests/test_circular_references.py
+++ b/tests/test_circular_references.py
@@ -89,11 +89,11 @@ def test_multiple_circular_references():
     d1 = {"id": "d1"}
     d2 = {"id": "d2"}
     d3 = {"id": "d3"}
-    
+
     d1["refs"] = [d2, d3]  # pyright: ignore
     d2["refs"] = [d1, d3]  # pyright: ignore
     d3["refs"] = [d1, d2]  # pyright: ignore
-    
+
     result = abbrev_obj(d1)
     assert "<circular reference>" in result
     assert "id=d1" in result


### PR DESCRIPTION
## Summary
- Fixed infinite recursion bug in `abbrev_obj()` when handling objects with circular references
- Added proper cycle detection by propagating the `visited` set through all recursive calls
- Added comprehensive test coverage for various circular reference scenarios

## Problem
The `abbrev_obj` function would cause infinite recursion when processing objects containing circular references. The issue was that the `_format_kvs` helper function wasn't receiving or passing the `visited` parameter, causing each recursive call to lose track of previously visited objects.

## Solution
- Added `visited: set[Any] | None = None` parameter to `_format_kvs` function
- Ensured `visited` is passed to all recursive `abbrev_obj` calls within `_format_kvs`
- Updated all calls from `abbrev_obj` to `_format_kvs` to include the `visited` parameter

## Test Plan
✅ Added comprehensive test coverage in `tests/test_circular_references.py`:
- Test circular references in dictionaries
- Test circular references in lists  
- Test mutual references between objects
- Test nested circular structures
- Test lists containing circular dictionaries
- Test deep nesting without circular references (control case)
- Test multiple circular reference patterns

✅ All tests pass
✅ Code passes linting (ruff)
✅ Code passes type checking (basedpyright)
✅ All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)